### PR TITLE
feat: add syncfork command to sync forks with upstream

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,12 @@ Install dependencies with `npm i`
 1. `npm run package`
 2. `npm run start`
 
+### Production build alpha install
+
+1. `npm run package`
+2. `npm pack`
+3. `npm i -g bisgit-<version>.tgz`
+
 ## Debug with VS Code
 
 - ensure you have extensions installed in [extensions.json](./.vscode/extensions.json)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Each of these commands work with `gi` or `bisgit`. Just found out gi isn't going
 - `gi whoami` shows github username.
 - `gi languages` prints the percentages of languages for this repo.
 - `gi coauthor <username?>` commits with a co-authorship description.
+- `gi syncfork` syncs main with upstream main (use `git pull` after).
 
 ### Utility
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -18,6 +18,7 @@ import { rebranch } from './rebranch';
 import { remoteDefault } from './remoteDefault';
 import { savepoint } from './savepoint';
 import { sha } from './sha';
+import { syncfork } from './syncfork';
 import { track } from './track';
 import { update } from './update';
 import { showVersion } from './version';
@@ -46,6 +47,7 @@ const commands: Record<string, () => void | Promise<void>> = {
   'remote-default': remoteDefault,
   savepoint,
   sha,
+  syncfork,
   track,
   update,
   '--version': showVersion,

--- a/src/commands/languages.tsx
+++ b/src/commands/languages.tsx
@@ -1,45 +1,40 @@
 import { execAsync } from '../utils/commands';
 import { render } from 'ink';
 import { WithProgress } from '../components/withProgress';
+import { getRepoName } from '../utils/git/gh';
 
 export async function languages() {
-	const promise = (async () => {
-		const repoName = await getGithubRepoName();
-		return await getRepoLanguages(repoName);
-	})();
+  const promise = (async () => {
+    const { repo, owner } = await getRepoName();
+    return await getRepoLanguages(`${owner}/${repo}`);
+  })();
 
-	render(<WithProgress msg="Fetching repo languages" promise={promise} />);
-	const data = await promise;
+  render(<WithProgress msg="Fetching repo languages" promise={promise} />);
+  const data = await promise;
 
-	const total = Object.values(data).reduce((sum, val) => sum + val, 0);
-	const langDetails = Object.entries(data).map(
-		([lang, bytes]) => `${lang}: ${Math.round((bytes / total) * 100)}% - ${formatBytes(bytes)}`
-	);
+  const total = Object.values(data).reduce((sum, val) => sum + val, 0);
+  const langDetails = Object.entries(data).map(
+    ([lang, bytes]) => `${lang}: ${Math.round((bytes / total) * 100)}% - ${formatBytes(bytes)}`
+  );
 
-	console.log(langDetails.join('\n'));
-}
-
-/** returns `<owner>/<repo>` */
-async function getGithubRepoName() {
-	const { stdout } = await execAsync('gh repo view --json nameWithOwner -q .nameWithOwner');
-	return stdout.trim();
+  console.info(langDetails.join('\n'));
 }
 
 /** Bytes per language */
 type LangData = {
-	[language: string]: number;
+  [language: string]: number;
 };
 
 async function getRepoLanguages(repo: string): Promise<LangData> {
-	const { stdout } = await execAsync(`gh api repos/${repo}/languages`);
-	return JSON.parse(stdout.trim());
+  const { stdout } = await execAsync(`gh api repos/${repo}/languages`);
+  return JSON.parse(stdout.trim());
 }
 
 function formatBytes(bytes: number, decimals = 2) {
-	if (bytes === 0) return '0 B';
-	const k = 1024; // or 1000 for decimal
-	const dm = decimals < 0 ? 0 : decimals;
-	const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-	const i = Math.floor(Math.log(bytes) / Math.log(k));
-	return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+  if (bytes === 0) return '0 B';
+  const k = 1024; // or 1000 for decimal
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 }

--- a/src/commands/syncfork.tsx
+++ b/src/commands/syncfork.tsx
@@ -1,0 +1,29 @@
+import { render } from 'ink';
+import { WithProgress } from '../components/withProgress';
+import { execAsync } from '../utils/commands';
+import { getForkName, getRepoName } from '../utils/git/gh';
+import { requireRemote } from '../utils/guards';
+
+export async function syncfork() {
+  requireRemote();
+
+  const setupPromise = Promise.all([getRepoName(), getForkName()]);
+  render(<WithProgress promise={setupPromise} msg="Getting fork details" />);
+
+  const [repo, fork] = await setupPromise;
+  if (!fork.owner) {
+    console.error('This is not a fork');
+    process.exit(1);
+  }
+
+  const promise = execAsync(
+    `gh repo sync ${repo.owner}/${repo.repo} --source ${fork.owner}/${fork.repo}`
+  );
+
+  render(
+    <WithProgress
+      promise={promise}
+      msg={`Syncing fork ${repo.repo} with upstream ${fork.owner}/${fork.repo}`}
+    />
+  );
+}

--- a/src/utils/git/gh.ts
+++ b/src/utils/git/gh.ts
@@ -1,0 +1,19 @@
+import { execAsync } from '../commands';
+
+type RepoName = {
+  owner?: string;
+  repo?: string;
+};
+
+export async function getRepoName(): Promise<RepoName> {
+  const { stdout } = await execAsync('gh repo view --json nameWithOwner --jq .nameWithOwner');
+  const combined = stdout.trim();
+  const [owner, repo] = combined.split('/');
+  return { owner, repo };
+}
+
+export async function getForkName(): Promise<RepoName> {
+  const { stdout } = await execAsync('gh repo view --json parent');
+  const data = JSON.parse(stdout);
+  return { repo: data.parent?.name, owner: data.parent?.owner?.login };
+}


### PR DESCRIPTION
Implements #6 - adds a new 'gi syncfork' command that automatically detects the fork remote and repository name, then syncs the fork with its upstream using 'gh repo sync'.

## Changes

- Create getRepoName() helper to get the current repository name using gh repo view
- Create getForkName() helper to get the upstream fork name using gh repo view --json parent
- Create syncfork command that combines these helpers and calls gh repo sync
- Register syncfork command in commands index

## How to use

Run: gi syncfork

This automatically syncs your fork with its upstream repository without needing to know the exact upstream repository name.